### PR TITLE
Feature: NBA Service Layer Unit Tests

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -42,7 +42,7 @@ jobs:
           echo "Creating .env.local file in Edge Function Directory"
           cd ./supabase/functions
           echo "SUPABASE_URL=${LOCAL_SUPABASE_URL}" >> .env.local
-          echo "SUPABASE_SERVICE_ROLE_KEY=${LOCAL_SUPABASE_SERVICE_ROLE_KEY}" >> .env.local
+          echo "SUPABASE_ANON_KEY=${LOCAL_SUPABASE_SERVICE_ROLE_KEY}" >> .env.local
           echo "SPORTS_DATA_NBA_API_KEY=${SPORTS_DATA_NBA_API_KEY}" >> .env.local
       - run: |
           echo "Running Unit Tests"

--- a/supabase/functions/nba/index.ts
+++ b/supabase/functions/nba/index.ts
@@ -17,7 +17,7 @@ const APP = RouterBuilder.builder()
    * Resource Path: /nba/teams
    * Route/Endpoint to upsert NBA teams from Sportsdata.io to our in Supabase nba.teams DB Table.
   */
-  .addRoute(
+  .withRoute(
     SupportedHttpMethod.POST,
     "/teams", 
     nbaController.updateTeams.bind(nbaController),

--- a/supabase/functions/nba/service/NbaService.ts
+++ b/supabase/functions/nba/service/NbaService.ts
@@ -2,7 +2,7 @@ import { SupabaseDbDAO } from "../dao/SupabaseDbDAO.ts";
 import { NbaSportsDataDAO } from "../dao/NbaSportsDataDAO.ts";
 
 import { mapNbaTeamToDBRecord } from "../entity/NbaTeamRecord.ts";
-import * as TeamUtil from "../ro/SportsDataTeamRO.ts";
+import { SportsDataTeamRO, isValidTeam } from "../ro/SportsDataTeamRO.ts";
 
 import { NbaTeamRecord } from "../entity/NbaTeamRecord.ts";
 import { SupabaseSchemaType } from "../dao/SupabaseDbDAO.ts";
@@ -16,13 +16,13 @@ class NbaService {
     this.supabaseDbDao = supabaseDbDao;
   }
 
-  syncNbaTeamData = async () => {
-    const nbaAllTeamsResponse = await this.sportsDataDAO.getAllTeams();
+  syncNbaTeamData = async (): Promise<string> => {
+    const nbaAllTeamsResponse: SportsDataTeamRO[] = await this.sportsDataDAO.getAllTeams();
     if (!Array.isArray(nbaAllTeamsResponse) || nbaAllTeamsResponse.length === 0) {
         throw new Error('Invalid API response: expected array of teams');
     }
   
-    const validatedRecords: NbaTeamRecord[] = nbaAllTeamsResponse.filter(TeamUtil.isValidTeam).map(mapNbaTeamToDBRecord);
+    const validatedRecords: NbaTeamRecord[] = nbaAllTeamsResponse.filter(isValidTeam).map(mapNbaTeamToDBRecord);
     if (validatedRecords.length === 0) {
       throw new Error(`Invalid API Response: No valid data found in NBA All Teams Sports Data.`);
     }

--- a/supabase/functions/shared/EnvironmentVariables.ts
+++ b/supabase/functions/shared/EnvironmentVariables.ts
@@ -4,7 +4,7 @@ const SPORTS_DATA_API_KEY = Deno.env.get('SPORTS_DATA_NBA_API_KEY');
 
 try {
     if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SPORTS_DATA_API_KEY) {
-        throw new Error('Expected Env Variablse not set.');
+        throw new Error('Expected Environment Variables not set.');
     };
 } catch (error) {
     console.error('Error loading environment variables:', error);

--- a/supabase/functions/tests/integration/supabase-upsert-nba-teams.test.ts
+++ b/supabase/functions/tests/integration/supabase-upsert-nba-teams.test.ts
@@ -1,9 +1,10 @@
 import { createClient } from "supabase";
+import * as EnvironmentVariables from "../../shared/EnvironmentVariables.ts";
 
 // Replace with your local or remote Supabase API URL and service role key as needed
 const supabase = createClient(
-  "http://127.0.0.1:54321",
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
+  EnvironmentVariables.SUPABASE_URL!,
+  EnvironmentVariables.SUPABASE_ANON_KEY!
 );
 
 // Example upsert data, adjust as needed for your schema

--- a/supabase/functions/tests/unit/entity/NbaTeamRecord.test.ts
+++ b/supabase/functions/tests/unit/entity/NbaTeamRecord.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "jsr:@std/assert";
+import { mapNbaTeamToDBRecord } from "../../../nba/entity/NbaTeamRecord.ts";
+import { NbaTeamRecord } from "../../../nba/entity/NbaTeamRecord.ts";
+import { SportsDataTeamRO } from "../../../nba/ro/SportsDataTeamRO.ts";
+
+const validSportsDataTeam : SportsDataTeamRO = {
+  TeamID: 1,
+  Key: "GSW",
+  City: "San Francisco",
+  Name: "Warriors",
+  Conference: "Western",
+  Division: "Pacific",
+  Active: true,
+};
+
+// Example valid and invalid team data for SportsData.io
+const validTeam : NbaTeamRecord = {
+  teamid: 1,
+  teamabbreviation: "GSW",
+  city: "San Francisco",
+  teamname: "Warriors",
+  conference: "Western",
+  division: "Pacific",
+  active: true,
+  recordlastupdated: new Date().toISOString(),
+};
+
+Deno.test("mapTeamToDBRecord maps fields correctly", () => {
+  const transformed = mapNbaTeamToDBRecord(validSportsDataTeam);
+  assertEquals(transformed.teamid, validTeam.teamid);
+  assertEquals(transformed.teamabbreviation, validTeam.teamabbreviation);
+  assertEquals(transformed.city, validTeam.city);
+  assertEquals(transformed.teamname, validTeam.teamname);
+  assertEquals(transformed.conference, validTeam.conference);
+  assertEquals(transformed.division, validTeam.division);
+  assertEquals(transformed.active, validTeam.active);
+  assertEquals(typeof transformed.recordlastupdated,  "string");
+});

--- a/supabase/functions/tests/unit/index.test.ts
+++ b/supabase/functions/tests/unit/index.test.ts
@@ -17,7 +17,7 @@ const buildMockNbaControllerFromStubs = (stubs: {[key: string]: Mock.Stub} = def
 const defaultNbaController = buildMockNbaControllerFromStubs();
 
 const getAppWithMocks = (controller: NbaController = defaultNbaController) => RouterBuilder.builder().withBasePath("/nba")
-  .addRoute(
+  .withRoute(
     SupportedHttpMethod.POST,
     "/teams",
     controller.updateTeams.bind(controller),

--- a/supabase/functions/tests/unit/service/NbaService.test.ts
+++ b/supabase/functions/tests/unit/service/NbaService.test.ts
@@ -1,0 +1,98 @@
+import { assertEquals, assertRejects } from "deno/assert";
+import * as Mock from "deno/mock";
+import { NbaSportsDataDAO } from "../../../nba/dao/NbaSportsDataDAO.ts";
+import { SupabaseDbDAO, SupabaseSchemaType } from "../../../nba/dao/SupabaseDbDAO.ts";
+import { NbaService } from "../../../nba/service/NbaService.ts";
+import { SportsDataTeamRO } from "../../../nba/ro/SportsDataTeamRO.ts";
+
+const validSportsDataTeam : SportsDataTeamRO = {
+  TeamID: 1,
+  Key: "GSW",
+  City: "San Francisco",
+  Name: "Warriors",
+  Conference: "Western",
+  Division: "Pacific",
+  Active: true,
+};
+
+const invalidSportsDataTeam : unknown = {
+  TeamID: "not-a-number",
+  Key: "GSW",
+  City: "San Francisco",
+  Name: "Warriors",
+  Conference: "Western",
+  Division: "Pacific",
+  Active: true,
+};
+
+// Mock the DAO Layer to isolate the service layer
+const DEFAULT_MOCKS = {
+    nbaSportsDataDAO: {
+        getAllTeams: Mock.stub(NbaSportsDataDAO.prototype, "getAllTeams", async () => await Promise.resolve([validSportsDataTeam])),
+    },
+    supabaseDbDAO: {
+        upsertRecords: Mock.stub(SupabaseDbDAO.prototype, "upsertRecords", async () => await Promise.resolve({ data: null, error: null})),
+    },
+};
+
+const buildMockNbaServiceFromStubs = (stubs: {[key: string]: {[key: string]: Mock.Stub}} = DEFAULT_MOCKS) => {
+    const { nbaSportsDataDAO, supabaseDbDAO} = {...DEFAULT_MOCKS, ...stubs};
+    return new NbaService(nbaSportsDataDAO as unknown as NbaSportsDataDAO, supabaseDbDAO as unknown as SupabaseDbDAO<SupabaseSchemaType.NBA>);
+};
+
+// Create a test instance of the controller with the mocked service
+const defaultNbaService = buildMockNbaServiceFromStubs();
+
+Deno.test("syncNbaTeamData - handles successful SportsData response and Supabase DB upsert", async () => {
+    const result = await defaultNbaService.syncNbaTeamData();
+
+    assertEquals(result, "DB updated successfully.");
+});
+
+Deno.test("syncNbaTeamData - handles empty SportsData response - throws Error", () => {
+    const mockEmptySportsData = {
+        nbaSportsDataDAO: {
+            getAllTeams: Mock.stub(NbaSportsDataDAO.prototype, "getAllTeams", async () => await Promise.resolve([])),
+        }
+    };
+
+    try {
+        const nbaService = buildMockNbaServiceFromStubs(mockEmptySportsData);
+
+        assertRejects(() => nbaService.syncNbaTeamData(), Error, "Invalid API response: expected array of teams");
+    } finally {
+        mockEmptySportsData.nbaSportsDataDAO.getAllTeams.restore();
+    }
+});
+
+Deno.test("syncNbaTeamData - handles empty validated, mapped SportsDataTeamRO to NbaTeamRecords - throws Error", () => {
+    const mockInvalidSportsData = {
+        nbaSportsDataDAO: {
+            getAllTeams: Mock.stub(NbaSportsDataDAO.prototype, "getAllTeams", async () => await Promise.resolve([invalidSportsDataTeam as SportsDataTeamRO])),
+        }
+    };
+
+    try {
+        const nbaService = buildMockNbaServiceFromStubs(mockInvalidSportsData);
+
+        assertRejects(() => nbaService.syncNbaTeamData(), "Invalid API Response: No valid data found in NBA All Teams Sports Data."); 
+    } finally {
+        mockInvalidSportsData.nbaSportsDataDAO.getAllTeams.restore();
+    }
+});
+
+Deno.test("syncNbaTeamData - handles Supabase DB upsertRecords error - throws Error", () => {
+    const mockSupabaseDBUpsertError = {
+        supabaseDbDAO: {
+            upsertRecords: Mock.stub(SupabaseDbDAO.prototype, "upsertRecords", async () => await Promise.reject({ data: null, error: null})),
+        }
+    };
+
+    try {
+        const nbaService = buildMockNbaServiceFromStubs(mockSupabaseDBUpsertError);
+
+        assertRejects(() => nbaService.syncNbaTeamData());
+    } finally {
+        mockSupabaseDBUpsertError.supabaseDbDAO.upsertRecords.restore();
+    }
+});

--- a/supabase/functions/tests/unit/shared/RouterBuilder.test.ts
+++ b/supabase/functions/tests/unit/shared/RouterBuilder.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals, assertThrows } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { Context } from 'hono';
+import { RouterBuilder, SupportedHttpMethod } from '../../../shared/RouterBuilder.ts';
+
+Deno.test("build - should register routes correctly", () => {
+    const app = RouterBuilder.builder()
+        .withBasePath("/base-path")
+        .withRoute(SupportedHttpMethod.POST, "/test", async (c: Context) => await Promise.resolve(c.json({ success: true })))
+        .build();
+    
+    assertEquals(app.routes.length, 2);
+    assertEquals(app.routes[0].method, "POST");
+    assertEquals(app.routes[0].path, "/base-path/test");
+    assertEquals(app.routes[1].method, "ALL");
+    assertEquals(app.routes[1].path, "/base-path/test");
+});
+
+Deno.test("build - should throw error if base path is not set", () => {
+    assertThrows(
+        () => RouterBuilder.builder().build(),
+        Error,
+        "Base path is required and must be set using withBasePath"
+    );
+});
+
+Deno.test("withBasePath - should throw error for invalid base path", () => {
+    assertThrows(
+        () => RouterBuilder.builder().withBasePath("api"),
+        Error,
+        "Base path must start with a forward slash (/)"
+    );
+});
+
+Deno.test("addRoute - should throw error for duplicate route", () => {
+    const handler = async (c: Context) => await Promise.resolve(c.json({ success: true }));
+
+    assertThrows(
+        () => RouterBuilder.builder()
+            .withRoute(SupportedHttpMethod.POST, "/test", handler)
+            .withRoute(SupportedHttpMethod.POST, "/test", handler),
+        Error,
+        "Route POST /test already exists"
+    );
+});
+
+Deno.test("addRoute - should throw error for duplicate route", () => {
+    const handler = async (c: Context) => await Promise.resolve(c.json({ success: true }));
+
+    assertThrows(
+        () => RouterBuilder.builder()
+            .withRoute(SupportedHttpMethod.POST, "/test", handler)
+            .withRoute(SupportedHttpMethod.POST, "/test", handler),
+        Error,
+        "Route POST /test already exists"
+    );
+});


### PR DESCRIPTION
- Add Service Layer unit tests for updating nba teams from SportsData -> Supabase
- Refactor the RouterBuilder class to add the route to the underlying Hono instance in the withRoute method, rather than in the build method
   - the build method is now only responsible for final validation of field values before returning the underlying Hono instance that's been configured