### PR TITLE
POST /games/range endpoint

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,6 +16,7 @@ jobs:
       SUPABASE_URL: http://localhost:54321
       SUPABASE_ANON_KEY: test-anon-key
       SPORTS_DATA_NBA_API_KEY: test-sports-key
+      LOG_LEVEL: warn
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - 'main'
+  pull_request:
+    branches:
+      - '**'
   workflow_dispatch:
 
 jobs: 
@@ -22,7 +25,7 @@ jobs:
         with:
           deno-version: v2.x
       - name: Run unit tests
-        run: deno test --allow-env --allow-read --allow-net --env-file=../.env
+        run: deno test --allow-env --allow-read --allow-net
   deploy_db_migrations:
     runs-on: ubuntu-latest
     needs: unit_tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           deno-version: v2.x
       - name: Run unit tests
-        run: deno test --allow-env --allow-read --allow-net
+        run: deno test --allow-env --allow-read --allow-net --env-file=../.env
   deploy_db_migrations:
     runs-on: ubuntu-latest
     needs: unit_tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
-    branches:
-      - '**'
   workflow_dispatch:
 
 jobs: 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,27 @@ Supabase project to serve as the backend for Betchya.
 
 - `SupabaseDbDAO` testability
   - `constructor(schema, client?)` allows injecting a fake `SupabaseClient` in unit tests to avoid network/background intervals.
+
+## Endpoints
+
+- **POST /nba/games**
+  - Purpose: Sync games for a single day.
+  - Body: `{ "date"?: "YYYY-MM-DD" }` (optional; defaults to today UTC)
+  - Validation: Strict `YYYY-MM-DD` (zero‑padded) and real calendar date.
+  - Example:
+    ```bash
+    curl -X POST http://localhost:54321/functions/v1/nba/games \
+      -H "Content-Type: application/json" \
+      -d '{"date":"2025-03-01"}'
+    ```
+
+- **POST /nba/games/range**
+  - Purpose: Sync games for an inclusive date range.
+  - Body: `{ "startDate": "YYYY-MM-DD", "endDate": "YYYY-MM-DD" }`
+  - Validation: Strict `YYYY-MM-DD` and real calendar dates; `startDate <= endDate`; max 31 days.
+  - Example:
+    ```bash
+    curl -X POST http://localhost:54321/functions/v1/nba/games/range \
+      -H "Content-Type: application/json" \
+      -d '{"startDate":"2025-03-01","endDate":"2025-03-07"}'
+    ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # betchya-backend
+
 Supabase project to serve as the backend for Betchya.
 
 ## Local setup
@@ -23,25 +24,45 @@ Supabase project to serve as the backend for Betchya.
 
 - GitHub Actions workflow: `.github/workflows/testing.yml`
   - `unit_tests` job runs the Deno test suite.
-  - `deploy_db_migrations` and `deploy_edge_functions` are gated on `unit_tests`.
+  - `deploy_db_migrations` and `deploy_edge_functions` are gated on
+    `unit_tests`.
 
 ## Notable implementation notes
 
-- Layered architecture (Controller, Service, DAO, Entities, RO, Shared). Main function `nba` exposes endpoints like:
+- Layered architecture (Controller, Service, DAO, Entities, RO, Shared). Main
+  function `nba` exposes endpoints like:
   - `POST /nba/teams` – sync NBA teams into Supabase
   - `POST /nba/games` – sync NBA games for a date (expects `YYYY-MM-DD`)
-
 - `NbaController.updateGames()`
-  - Accepts only `YYYY-MM-DD` (zero‑padded) and validates real calendar dates (incl. leap year handling).
+  - Accepts only `YYYY-MM-DD` (zero‑padded) and validates real calendar dates
+    (incl. leap year handling).
 
 - `SupabaseDbDAO` testability
-  - `constructor(schema, client?)` allows injecting a fake `SupabaseClient` in unit tests to avoid network/background intervals.
+  - `constructor(schema, client?)` allows injecting a fake `SupabaseClient` in
+    unit tests to avoid network/background intervals.
+
+## Logging
+
+- Structured JSON logger at `supabase/functions/shared/Logger.ts`.
+- Control verbosity via `LOG_LEVEL` env: `debug`, `info`, `warn`, `error`
+  (default `info`).
+- CI sets `LOG_LEVEL=warn` to reduce noise.
+- Example line:
+  ```json
+  {
+    "ts": "2025-01-01T00:00:00.000Z",
+    "level": "warn",
+    "msg": "sportsdata non-ok GamesByDate",
+    "date": "2025-03-01",
+    "status": 429,
+    "statusText": "Too Many Requests"
+  }
+  ```
 
 ## Endpoints
 
 - **POST /nba/games**
   - Purpose: Sync games for a single day.
-  - Body: `{ "date"?: "YYYY-MM-DD" }` (optional; defaults to today UTC)
   - Validation: Strict `YYYY-MM-DD` (zero‑padded) and real calendar date.
   - Example:
     ```bash
@@ -53,7 +74,8 @@ Supabase project to serve as the backend for Betchya.
 - **POST /nba/games/range**
   - Purpose: Sync games for an inclusive date range.
   - Body: `{ "startDate": "YYYY-MM-DD", "endDate": "YYYY-MM-DD" }`
-  - Validation: Strict `YYYY-MM-DD` and real calendar dates; `startDate <= endDate`; max 31 days.
+  - Validation: Strict `YYYY-MM-DD` and real calendar dates;
+    `startDate <= endDate`; max 31 days.
   - Example:
     ```bash
     curl -X POST http://localhost:54321/functions/v1/nba/games/range \

--- a/supabase/functions/nba/controller/NbaController.ts
+++ b/supabase/functions/nba/controller/NbaController.ts
@@ -57,6 +57,54 @@ class NbaController {
             }
         }
     }
+    
+    updateGamesRange = async (context: Context) => {
+        try {
+            const body = await context.req.json<{ startDate?: string; endDate?: string }>().catch(() => ({}) as { startDate?: string; endDate?: string });
+            const rawStart = typeof body.startDate === 'string' ? body.startDate.trim() : undefined;
+            const rawEnd = typeof body.endDate === 'string' ? body.endDate.trim() : undefined;
+
+            if (!rawStart || !rawEnd) {
+                return context.json({ message: "Missing required startDate and/or endDate." }, { status: 400 });
+            }
+
+            const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+            const validFormatStart = datePattern.test(rawStart);
+            const validFormatEnd = datePattern.test(rawEnd);
+
+            const isRealDate = (d: string) => {
+                const [y, m, d2] = d.split("-").map((n) => Number(n));
+                const dt = new Date(Date.UTC(y, m - 1, d2));
+                return dt.getUTCFullYear() === y && (dt.getUTCMonth() + 1) === m && dt.getUTCDate() === d2;
+            };
+
+            if (!validFormatStart || !validFormatEnd || !isRealDate(rawStart) || !isRealDate(rawEnd)) {
+                return context.json({ message: "Invalid dates. Expected format: YYYY-MM-DD" }, { status: 400 });
+            }
+
+            const start = new Date(`${rawStart}T00:00:00Z`).getTime();
+            const end = new Date(`${rawEnd}T00:00:00Z`).getTime();
+            if (isNaN(start) || isNaN(end) || start > end) {
+                return context.json({ message: "Invalid range. startDate must be less than or equal to endDate." }, { status: 400 });
+            }
+
+            // Optional guard: prevent excessively large ranges (e.g., > 31 days)
+            const maxDays = 31;
+            const days = Math.floor((end - start) / (24 * 60 * 60 * 1000)) + 1;
+            if (days > maxDays) {
+                return context.json({ message: `Range too large. Max ${maxDays} days.` }, { status: 400 });
+            }
+
+            const successMessage = await this.nbaService.syncNbaGamesRange(rawStart, rawEnd);
+            return context.json({ message: successMessage }, { status: 200 });
+        } catch (error: Error | unknown) {
+            if (error instanceof Error) {
+                return context.json({ message: `Failed to update NBA games range: ${error.message}` }, { status: 500 });
+            } else {
+                return context.json({ message: "Failed to update NBA games range: Unknown error" }, { status: 500 });
+            }
+        }
+    }
 };
 
 export { NbaController };

--- a/supabase/functions/nba/controller/NbaController.ts
+++ b/supabase/functions/nba/controller/NbaController.ts
@@ -1,5 +1,6 @@
 import { Context } from "hono";
 import { NbaService } from "../service/NbaService.ts";
+import { isValidYYYYMMDDDate, normalizeYYYYMMDD } from "../../shared/DateValidation.ts";
 
 class NbaController {
     
@@ -25,27 +26,12 @@ class NbaController {
     updateGames = async (context: Context) => {
         try {
             const body = await context.req.json<{ date?: string }>().catch(() => ({} as { date?: string }));
-            const rawDate = typeof body.date === 'string' ? body.date.trim() : undefined;
-            // If a date is provided, validate format (YYYY-MM-DD) and that it's a valid calendar date
-            if (rawDate) {
-                const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-                const validFormat = datePattern.test(rawDate);
-                let validDate = false;
-                if (validFormat) {
-                    const [yearStr, monthStr, dayStr] = rawDate.split("-");
-                    const year = Number(yearStr);
-                    const month = Number(monthStr);
-                    const day = Number(dayStr);
-                    // Construct a UTC date and compare components to ensure no rollover occurred
-                    const dt = new Date(Date.UTC(year, month - 1, day));
-                    validDate = dt.getUTCFullYear() === year && (dt.getUTCMonth() + 1) === month && dt.getUTCDate() === day;
-                }
-                if (!validFormat || !validDate) {
-                    return context.json({ message: "Invalid date. Expected format: YYYY-MM-DD" }, { status: 400 });
-                }
+            const normalized = normalizeYYYYMMDD(body.date);
+            if (normalized && !isValidYYYYMMDDDate(normalized)) {
+                return context.json({ message: "Invalid date. Expected format: YYYY-MM-DD" }, { status: 400 });
             }
             // Service will default to today's date if no date is provided
-            const date = rawDate && rawDate.length > 0 ? rawDate : undefined;
+            const date = normalized;
 
             const successMessage = await this.nbaService.syncNbaGameData(date);
             return context.json({ message: successMessage }, { status: 200 });
@@ -61,24 +47,14 @@ class NbaController {
     updateGamesRange = async (context: Context) => {
         try {
             const body = await context.req.json<{ startDate?: string; endDate?: string }>().catch(() => ({}) as { startDate?: string; endDate?: string });
-            const rawStart = typeof body.startDate === 'string' ? body.startDate.trim() : undefined;
-            const rawEnd = typeof body.endDate === 'string' ? body.endDate.trim() : undefined;
+            const rawStart = normalizeYYYYMMDD(body.startDate);
+            const rawEnd = normalizeYYYYMMDD(body.endDate);
 
             if (!rawStart || !rawEnd) {
                 return context.json({ message: "Missing required startDate and/or endDate." }, { status: 400 });
             }
 
-            const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-            const validFormatStart = datePattern.test(rawStart);
-            const validFormatEnd = datePattern.test(rawEnd);
-
-            const isRealDate = (d: string) => {
-                const [y, m, d2] = d.split("-").map((n) => Number(n));
-                const dt = new Date(Date.UTC(y, m - 1, d2));
-                return dt.getUTCFullYear() === y && (dt.getUTCMonth() + 1) === m && dt.getUTCDate() === d2;
-            };
-
-            if (!validFormatStart || !validFormatEnd || !isRealDate(rawStart) || !isRealDate(rawEnd)) {
+            if (!isValidYYYYMMDDDate(rawStart) || !isValidYYYYMMDDDate(rawEnd)) {
                 return context.json({ message: "Invalid dates. Expected format: YYYY-MM-DD" }, { status: 400 });
             }
 

--- a/supabase/functions/nba/dao/NbaSportsDataDAO.ts
+++ b/supabase/functions/nba/dao/NbaSportsDataDAO.ts
@@ -1,6 +1,7 @@
 import { SportsDataTeamRO } from "../ro/SportsDataTeamRO.ts"; // Import the type for SportsData.io NBA Team response
 import { SportsDataGameRO } from "../ro/SportsDataGameRO.ts"; // Import the type for SportsData.io NBA Game response
 import * as EnvironmentVariables from "../../shared/EnvironmentVariables.ts"; // Import environment variables
+import { Logger } from "../../shared/Logger.ts";
 
 class NbaSportsDataDAO {
   private apiKey: string;
@@ -22,8 +23,10 @@ class NbaSportsDataDAO {
    * @throws An error if the fetch request fails or the response is invalid.
    */
   getAllTeams = async (): Promise<SportsDataTeamRO[]> => {
+    Logger.debug("sportsdata fetch AllTeams", { url: this.allTeamsEndpoint.toString() });
     const response = await fetch(this.allTeamsEndpoint);
     if (!response.ok) {
+      Logger.warn("sportsdata non-ok AllTeams", { status: response.status, statusText: response.statusText });
       throw new Error(`Failed to fetch NBA all teams data from Sportsdata.io  ${response.status} ${response.statusText}`);
     }
 
@@ -31,6 +34,7 @@ class NbaSportsDataDAO {
       return await response.json() as SportsDataTeamRO[];
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      Logger.error("sportsdata json parse error AllTeams", { url: this.allTeamsEndpoint.toString(), error: errorMessage });
       throw new Error(`Failed to parse JSON response from Sportsdata.io ${this.allTeamsEndpoint}: ${errorMessage}`);
     }
   };
@@ -49,8 +53,10 @@ class NbaSportsDataDAO {
     }
 
     const endpoint = new URL(`${this.sportsDataDomain}/v3/nba/scores/json/GamesByDate/${date}?key=${this.apiKey}`);
+    Logger.debug("sportsdata fetch GamesByDate", { date, url: endpoint.toString() });
     const response = await fetch(endpoint);
     if (!response.ok) {
+      Logger.warn("sportsdata non-ok GamesByDate", { date, status: response.status, statusText: response.statusText });
       throw new Error(`Failed to fetch NBA games for ${date} from Sportsdata.io ${response.status} ${response.statusText}`);
     }
 
@@ -58,6 +64,7 @@ class NbaSportsDataDAO {
       return await response.json() as SportsDataGameRO[];
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      Logger.error("sportsdata json parse error GamesByDate", { date, url: endpoint.toString(), error: errorMessage });
       throw new Error(`Failed to parse JSON response from Sportsdata.io ${endpoint}: ${errorMessage}`);
     }
   }

--- a/supabase/functions/nba/index.ts
+++ b/supabase/functions/nba/index.ts
@@ -32,6 +32,11 @@ const APP = RouterBuilder.builder()
     "/games",
     nbaController.updateGames.bind(nbaController),
   )
+  .withRoute(
+    SupportedHttpMethod.POST,
+    "/games/range",
+    nbaController.updateGamesRange.bind(nbaController),
+  )
   //TODO add other NBA endpoints for handling players, games, etc. as needed
   .build();
 

--- a/supabase/functions/nba/service/NbaService.ts
+++ b/supabase/functions/nba/service/NbaService.ts
@@ -63,6 +63,22 @@ class NbaService {
 
     return `Games updated successfully for ${targetDate}.`;
   }
+
+  syncNbaGamesRange = async (startDate: string, endDate: string): Promise<string> => {
+    // Iterate inclusive from startDate to endDate (YYYY-MM-DD)
+    const [sy, sm, sd] = startDate.split("-").map((n) => Number(n));
+    const [ey, em, ed] = endDate.split("-").map((n) => Number(n));
+    let cur = new Date(Date.UTC(sy, sm - 1, sd));
+    const end = new Date(Date.UTC(ey, em - 1, ed));
+
+    while (cur.getTime() <= end.getTime()) {
+      const iso = cur.toISOString().slice(0, 10);
+      await this.syncNbaGameData(iso);
+      // next day UTC
+      cur = new Date(cur.getTime() + 24 * 60 * 60 * 1000);
+    }
+    return `Games updated successfully for range ${startDate} to ${endDate}.`;
+  }
 }
 
 export { NbaService };

--- a/supabase/functions/nba/service/NbaService.ts
+++ b/supabase/functions/nba/service/NbaService.ts
@@ -8,6 +8,7 @@ import { SportsDataGameRO, isValidGame } from "../ro/SportsDataGameRO.ts";
 import { NbaTeamRecord } from "../entity/NbaTeamRecord.ts";
 import { mapSportsDataGameToDBRecord } from "../entity/NbaGameRecord.ts";
 import type { NbaGameRecord } from "../entity/NbaGameRecord.ts";
+import { Logger } from "../../shared/Logger.ts";
 
 class NbaService {
   private sportsDataDAO: NbaSportsDataDAO;
@@ -66,6 +67,7 @@ class NbaService {
 
   syncNbaGamesRange = async (startDate: string, endDate: string): Promise<string> => {
     // Iterate inclusive from startDate to endDate (YYYY-MM-DD)
+    Logger.info("range sync start", { startDate, endDate });
     const [sy, sm, sd] = startDate.split("-").map((n) => Number(n));
     const [ey, em, ed] = endDate.split("-").map((n) => Number(n));
     let cur = new Date(Date.UTC(sy, sm - 1, sd));
@@ -73,10 +75,18 @@ class NbaService {
 
     while (cur.getTime() <= end.getTime()) {
       const iso = cur.toISOString().slice(0, 10);
-      await this.syncNbaGameData(iso);
+      try {
+        await this.syncNbaGameData(iso);
+      } catch (e) {
+        // Log and rethrow to preserve current fail-fast behavior
+        const msg = e instanceof Error ? e.message : String(e);
+        Logger.warn("range day failed", { date: iso, error: msg });
+        throw e;
+      }
       // next day UTC
       cur = new Date(cur.getTime() + 24 * 60 * 60 * 1000);
     }
+    Logger.info("range sync done", { startDate, endDate });
     return `Games updated successfully for range ${startDate} to ${endDate}.`;
   }
 }

--- a/supabase/functions/shared/DateValidation.ts
+++ b/supabase/functions/shared/DateValidation.ts
@@ -1,0 +1,21 @@
+// Shared date validation utilities
+// Strictly validate YYYY-MM-DD (zero-padded) and ensure it's a real calendar date in UTC.
+
+export function isValidYYYYMMDDDate(raw: string): boolean {
+  if (typeof raw !== "string") return false;
+  const s = raw.trim();
+  const pattern = /^\d{4}-\d{2}-\d{2}$/;
+  if (!pattern.test(s)) return false;
+  const [yStr, mStr, dStr] = s.split("-");
+  const y = Number(yStr);
+  const m = Number(mStr);
+  const d = Number(dStr);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() + 1 === m && dt.getUTCDate() === d;
+}
+
+export function normalizeYYYYMMDD(raw?: string): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const s = raw.trim();
+  return s.length > 0 ? s : undefined;
+}

--- a/supabase/functions/shared/Logger.ts
+++ b/supabase/functions/shared/Logger.ts
@@ -1,0 +1,54 @@
+// Simple structured JSON logger with level control via LOG_LEVEL env var.
+// Levels: debug < info < warn < error
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const levelOrder: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+function getCurrentLevel(): LogLevel {
+  const raw = (Deno.env.get("LOG_LEVEL") ?? "info").toLowerCase();
+  if (raw === "debug" || raw === "info" || raw === "warn" || raw === "error") return raw;
+  return "info";
+}
+
+function shouldLog(target: LogLevel): boolean {
+  const curr = getCurrentLevel();
+  return levelOrder[target] >= levelOrder[curr];
+}
+
+function emit(level: LogLevel, msg: string, context?: Record<string, unknown>) {
+  if (!shouldLog(level)) return;
+  const payload = {
+    ts: new Date().toISOString(),
+    level,
+    msg,
+    ...(context ?? {}),
+  };
+  const line = JSON.stringify(payload);
+  switch (level) {
+    case "debug":
+      console.debug(line);
+      break;
+    case "info":
+      console.info(line);
+      break;
+    case "warn":
+      console.warn(line);
+      break;
+    case "error":
+      console.error(line);
+      break;
+  }
+}
+
+export const Logger = {
+  debug: (msg: string, ctx?: Record<string, unknown>) => emit("debug", msg, ctx),
+  info: (msg: string, ctx?: Record<string, unknown>) => emit("info", msg, ctx),
+  warn: (msg: string, ctx?: Record<string, unknown>) => emit("warn", msg, ctx),
+  error: (msg: string, ctx?: Record<string, unknown>) => emit("error", msg, ctx),
+};

--- a/supabase/functions/tests/unit/controller/NbaControllerGamesRange.test.ts
+++ b/supabase/functions/tests/unit/controller/NbaControllerGamesRange.test.ts
@@ -1,0 +1,134 @@
+import { assertEquals } from "deno/assert";
+import * as Mock from "deno/mock";
+import { RouterBuilder, SupportedHttpMethod } from "../../../shared/RouterBuilder.ts";
+import { NbaController } from "../../../nba/controller/NbaController.ts";
+import { NbaService } from "../../../nba/service/NbaService.ts";
+
+// Helper to build app with a mocked controller
+const getAppWithController = (controller: NbaController) => RouterBuilder.builder()
+  .withBasePath("/nba")
+  .withRoute(
+    SupportedHttpMethod.POST,
+    "/games/range",
+    controller.updateGamesRange.bind(controller),
+  )
+  .build();
+
+Deno.test("POST /nba/games/range - invalid format returns 400 and does not call service", async () => {
+  const mocks = {
+    syncNbaGamesRange: Mock.stub(NbaService.prototype, "syncNbaGamesRange", async () => await Promise.resolve("ok")),
+  };
+  try {
+    const controller = new NbaController(mocks as unknown as NbaService);
+    const app = getAppWithController(controller);
+
+    const req = new Request("http://localhost/nba/games/range", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ startDate: "2025-2-1", endDate: "2025-03-01" }), // bad start format
+    });
+
+    const res = await app.fetch(req);
+    assertEquals(res.status, 400);
+    const body = await res.json();
+    assertEquals(body.message, "Invalid dates. Expected format: YYYY-MM-DD");
+    assertEquals(mocks.syncNbaGamesRange.calls.length, 0);
+  } finally {
+    mocks.syncNbaGamesRange.restore();
+  }
+});
+
+Deno.test("POST /nba/games/range - end before start returns 400", async () => {
+  const mocks = {
+    syncNbaGamesRange: Mock.stub(NbaService.prototype, "syncNbaGamesRange", async () => await Promise.resolve("ok")),
+  };
+  try {
+    const controller = new NbaController(mocks as unknown as NbaService);
+    const app = getAppWithController(controller);
+
+    const req = new Request("http://localhost/nba/games/range", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ startDate: "2025-03-02", endDate: "2025-03-01" }),
+    });
+
+    const res = await app.fetch(req);
+    assertEquals(res.status, 400);
+    const body = await res.json();
+    assertEquals(body.message, "Invalid range. startDate must be less than or equal to endDate.");
+    assertEquals(mocks.syncNbaGamesRange.calls.length, 0);
+  } finally {
+    mocks.syncNbaGamesRange.restore();
+  }
+});
+
+Deno.test("POST /nba/games/range - trims whitespace and accepts valid dates", async () => {
+  const mocks = {
+    syncNbaGamesRange: Mock.stub(NbaService.prototype, "syncNbaGamesRange", async () => await Promise.resolve("ok")),
+  };
+  try {
+    const controller = new NbaController(mocks as unknown as NbaService);
+    const app = getAppWithController(controller);
+
+    const req = new Request("http://localhost/nba/games/range", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ startDate: " 2025-03-01 ", endDate: " 2025-03-03 " }),
+    });
+
+    const res = await app.fetch(req);
+    assertEquals(res.status, 200);
+    assertEquals(mocks.syncNbaGamesRange.calls.length, 1);
+    const [firstCallArgs] = mocks.syncNbaGamesRange.calls;
+    assertEquals(firstCallArgs.args[0], "2025-03-01");
+    assertEquals(firstCallArgs.args[1], "2025-03-03");
+  } finally {
+    mocks.syncNbaGamesRange.restore();
+  }
+});
+
+Deno.test("POST /nba/games/range - leap day accepted", async () => {
+  const mocks = {
+    syncNbaGamesRange: Mock.stub(NbaService.prototype, "syncNbaGamesRange", async () => await Promise.resolve("ok")),
+  };
+  try {
+    const controller = new NbaController(mocks as unknown as NbaService);
+    const app = getAppWithController(controller);
+
+    const req = new Request("http://localhost/nba/games/range", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ startDate: "2024-02-29", endDate: "2024-03-01" }),
+    });
+
+    const res = await app.fetch(req);
+    assertEquals(res.status, 200);
+    assertEquals(mocks.syncNbaGamesRange.calls.length, 1);
+  } finally {
+    mocks.syncNbaGamesRange.restore();
+  }
+});
+
+Deno.test("POST /nba/games/range - range too large returns 400", async () => {
+  const mocks = {
+    syncNbaGamesRange: Mock.stub(NbaService.prototype, "syncNbaGamesRange", async () => await Promise.resolve("ok")),
+  };
+  try {
+    const controller = new NbaController(mocks as unknown as NbaService);
+    const app = getAppWithController(controller);
+
+    const req = new Request("http://localhost/nba/games/range", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ startDate: "2025-01-01", endDate: "2025-02-15" }), // 46 days
+    });
+
+    const res = await app.fetch(req);
+    assertEquals(res.status, 400);
+    const body = await res.json();
+    assertEquals(body.message, "Range too large. Max 31 days.");
+    assertEquals(mocks.syncNbaGamesRange.calls.length, 0);
+  } finally {
+    mocks.syncNbaGamesRange.restore();
+  }
+});

--- a/supabase/functions/tests/unit/service/NbaServiceGamesRange.test.ts
+++ b/supabase/functions/tests/unit/service/NbaServiceGamesRange.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "deno/assert";
+import * as Mock from "deno/mock";
+import { NbaService } from "../../../nba/service/NbaService.ts";
+import { NbaSportsDataDAO } from "../../../nba/dao/NbaSportsDataDAO.ts";
+import { SupabaseDbDAO } from "../../../nba/dao/SupabaseDbDAO.ts";
+
+Deno.test("NbaService.syncNbaGamesRange - loops per day and calls syncNbaGameData", async () => {
+  // Arrange
+  const sportsDao = {} as unknown as NbaSportsDataDAO;
+  const dbDao = {} as unknown as SupabaseDbDAO;
+  const svc = new NbaService(sportsDao, dbDao);
+
+  const callArgs: string[] = [];
+  const stub = Mock.stub(svc, "syncNbaGameData", async (date?: string) => {
+    if (date) callArgs.push(date);
+    return await Promise.resolve(`ok ${date}`);
+  });
+  try {
+    const msg = await svc.syncNbaGamesRange("2025-03-01", "2025-03-03");
+    assertEquals(callArgs, ["2025-03-01", "2025-03-02", "2025-03-03"]);
+    assertEquals(typeof msg, "string");
+  } finally {
+    stub.restore();
+  }
+});

--- a/supabase/functions/tests/unit/shared/DateValidation.test.ts
+++ b/supabase/functions/tests/unit/shared/DateValidation.test.ts
@@ -1,0 +1,19 @@
+import { assertEquals } from "deno/assert";
+import { isValidYYYYMMDDDate, normalizeYYYYMMDD } from "../../../shared/DateValidation.ts";
+
+Deno.test("isValidYYYYMMDDDate - accepts valid dates incl leap day", () => {
+  assertEquals(isValidYYYYMMDDDate("2025-03-01"), true);
+  assertEquals(isValidYYYYMMDDDate("2024-02-29"), true); // leap year
+});
+
+Deno.test("isValidYYYYMMDDDate - rejects invalid formats and invalid calendar dates", () => {
+  assertEquals(isValidYYYYMMDDDate("2025-3-1"), false); // not zero-padded
+  assertEquals(isValidYYYYMMDDDate("2025-02-30"), false); // invalid calendar
+  assertEquals(isValidYYYYMMDDDate("not-a-date"), false);
+});
+
+Deno.test("normalizeYYYYMMDD - trims and returns undefined when empty or non-string", () => {
+  assertEquals(normalizeYYYYMMDD(" 2025-03-01 "), "2025-03-01");
+  assertEquals(normalizeYYYYMMDD("   "), undefined);
+  assertEquals(normalizeYYYYMMDD(undefined), undefined);
+});


### PR DESCRIPTION
/games/range endpoint to backload games data for a given range of dates.

Implementation highlights
* Controller: NbaController.updateGames() and updateGamesRange() with strict date validation using shared utils  isValidYYYYMMDDDate()  and  normalizeYYYYMMDD()  from  supabase/functions/shared/DateValidation.ts .
* Service: NbaService.syncNbaGamesRange() loops per-day and reuses syncNbaGameData().
* Routes: POST /nba/games, POST /nba/games/range in  supabase/functions/nba/index.ts .
* Tests: Controller and service range tests added, plus shared validator tests. Suite currently green.
